### PR TITLE
Fix debug build due to undefined "z_error" and "z_verbose"

### DIFF
--- a/libz/deflate.c
+++ b/libz/deflate.c
@@ -49,6 +49,8 @@
 
 /* @(#) $Id$ */
 
+#include <stdio.h>
+
 #include "deflate.h"
 
 const char deflate_copyright[] =
@@ -1323,11 +1325,6 @@ static void check_match(s, start, match, length)
       do {
          fprintf(stderr, "%c%c", s->window[match++], s->window[start++]);
       } while (--length != 0);
-      z_error("invalid match");
-   }
-   if (z_verbose > 1) {
-      fprintf(stderr,"\\[%d,%d]", start-match, length);
-      do { putc(s->window[start++], stderr); } while (--length != 0);
    }
 }
 #else

--- a/libz/trees.c
+++ b/libz/trees.c
@@ -159,15 +159,7 @@ static void copy_block     (deflate_state *s, charf *buf, unsigned len,
 static void gen_trees_header (void);
 #endif
 
-#ifndef DEBUG
-#  define send_code(s, c, tree) send_bits(s, tree[c].Code, tree[c].Len)
-/* Send a code of the given tree. c and tree must not have side effects */
-
-#else /* DEBUG */
-#  define send_code(s, c, tree) \
-{ if (z_verbose>2) fprintf(stderr,"\ncd %3d ",(c)); \
-   send_bits(s, tree[c].Code, tree[c].Len); }
-#endif
+#define send_code(s, c, tree) send_bits(s, tree[c].Code, tree[c].Len)
 
 /* ===========================================================================
  * Output a short LSB first on the stream.


### PR DESCRIPTION
We could also readd the definitions in libretro/libretro-common. They got removed in https://github.com/libretro/libretro-common/commit/1678cd570ae44544b3865cf18d3668090bb404f3#diff-733eae7443b91d97af24c3578b65e781L227. Just let me know what you prefer.

I found this when trying to compile a debug build of chailove after they switched to a libretro-deps submodule: https://github.com/libretro/libretro-chailove/pull/243