### PR TITLE
typo/cleanup for unzip

### DIFF
--- a/unzip/unzip.h
+++ b/unzip/unzip.h
@@ -119,9 +119,7 @@ typedef struct unz_file_info_s
     tm_unz tmu_date;
 } unz_file_info;
 
-extern int  unzStringFileNameCompare OF ((const char* fileName1,
-                                                 const char* fileName2,
-                                                 int iCaseSensitivity));
+extern int  unzStringFileNameCompare (const char* fileName1, const char* fileName2, int iCaseSensitivity);
 /*
    Compare two filename (fileName1,fileName2).
    If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)

--- a/unzip/zlib.h
+++ b/unzip/zlib.h
@@ -1256,7 +1256,7 @@ typedef voidp gzFile;       /* opaque gzip file descriptor */
    error.
 */
 
- int VA gzprintf (gzFile file, const char *format, ...);
+ int gzprintf (gzFile file, const char *format, ...);
 /*
      Converts, formats, and writes the arguments to the compressed file under
    control of the format string, as in fprintf.  gzprintf returns the number of


### PR DESCRIPTION
this looks like a stray copy/paste kind of error left over from the cleanup in https://github.com/libretro/libretro-deps/commit/06fd4c67ae148a591ca10d5f3e3da40ad8c48277