### PR TITLE
freetype: fix two autofit function-pointer signature mismatches that trap on WebAssembly

### DIFF
--- a/freetype/src/autofit/afdummy.c
+++ b/freetype/src/autofit/afdummy.c
@@ -38,13 +38,15 @@
 
 
   static FT_Error
-  af_dummy_hints_apply( FT_UInt        glyph_index,
-                        AF_GlyphHints  hints,
-                        FT_Outline*    outline )
+  af_dummy_hints_apply( FT_UInt          glyph_index,
+                        AF_GlyphHints    hints,
+                        FT_Outline*      outline,
+                        AF_StyleMetrics  metrics )
   {
     FT_Error  error;
 
     FT_UNUSED( glyph_index );
+    FT_UNUSED( metrics );
 
 
     error = af_glyph_hints_reload( hints, outline );

--- a/freetype/src/autofit/aftypes.h
+++ b/freetype/src/autofit/aftypes.h
@@ -221,7 +221,15 @@ extern void*  _af_debug_hints;
   (*AF_WritingSystem_InitHintsFunc)( AF_GlyphHints    hints,
                                      AF_StyleMetrics  metrics );
 
-  typedef void
+  /* All four implementations assigned to this pointer                     */
+  /* (af_latin_hints_apply, af_cjk_hints_apply, af_indic_hints_apply and    */
+  /* af_dummy_hints_apply) are declared `static FT_Error' and force-cast    */
+  /* at assignment; see each AF_DEFINE_WRITING_SYSTEM_CLASS block.  Native  */
+  /* ABIs tolerate a caller ignoring a returned value, but WebAssembly's    */
+  /* `call_indirect' checks the signature and traps.  The sole call site,   */
+  /* in afloader.c, already discards the result as a bare statement, so     */
+  /* declaring the real return type changes no behaviour.                   */
+  typedef FT_Error
   (*AF_WritingSystem_ApplyHintsFunc)( FT_UInt          glyph_index,
                                       AF_GlyphHints    hints,
                                       FT_Outline*      outline,


### PR DESCRIPTION
`AF_WritingSystem_ApplyHintsFunc` is declared returning `void`, but all four
implementations assigned to it (`af_latin_hints_apply`, `af_cjk_hints_apply`,
`af_indic_hints_apply`, `af_dummy_hints_apply`) are `static FT_Error` and
force-cast at assignment. Separately, `af_dummy_hints_apply` takes three
parameters where the typedef declares four.

Native ABIs tolerate both. WebAssembly does not: `call_indirect` checks return
type and arity against the declared type and traps with "function signature
mismatch", which is fatal to the module. The arity mismatch is on the dummy
writing system, the fallback for glyphs the style classifier maps to no script,
so it is hit readily.

Both signatures now match what FreeType ships upstream. Behaviour is unchanged
elsewhere: the sole call site in `afloader.c` already discards the result, and
`af_dummy_hints_apply` never reads the parameter it was missing.

Found building `scummvm_libretro` for Emscripten.
